### PR TITLE
Fix links for board versions in 'montagem' subsection

### DIFF
--- a/franzininho-diy/montagem-da-franzininho-diy/README.md
+++ b/franzininho-diy/montagem-da-franzininho-diy/README.md
@@ -16,8 +16,8 @@ Você também deve separar os componentes para deixar organizado, para que facil
 {% hint style="warning" %}
 Verifique qual versão da placa Franzininho DIY você tem em mãos e siga as instruções de montagem:
 
-*  Montando a Versão [V1RV0](https://franzininho.gitbook.io/franzininho-docs/~/edit/drafts/-LJfwaN2OUG0WGA8mcr_/franzininho-diy/montagem-da-franzininho-diy/versao-1)
-*  Montando a Versão [V2RV0](https://franzininho.gitbook.io/franzininho-docs/~/edit/drafts/-LJfwaN2OUG0WGA8mcr_/franzininho-diy/montagem-da-franzininho-diy/versao-2)
+*  Montando a Versão [V1RV0](versao-1.md)
+*  Montando a Versão [V2RV0](versao-2.md)
 {% endhint %}
 
 


### PR DESCRIPTION
Os links da página de montagem para cada uma das versões da placa não estão funcionando, redirecionando para uma página com "Restricted Access".
Esse patch modifica os links para que sejam links internos do gitbook, apontando para as páginas de cada uma das versões da placa.